### PR TITLE
ユーザの検索機能 #12

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -87,8 +87,7 @@ p {
   width: 500px;
 }
 .submit {
-
-  width:  100px;
+  width: 100px;
 }
 
 /* footer */

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -83,6 +83,14 @@ p {
   }
 }
 
+.text_field {
+  width: 500px;
+}
+.submit {
+
+  width:  100px;
+}
+
 /* footer */
 
 footer {

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,0 +1,6 @@
+class SearchesController < ApplicationController
+  def search
+    @content=params[:content]
+    @records=User.search_for(@content)
+  end
+end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,6 +1,6 @@
 class SearchesController < ApplicationController
   def search
-    @keyword=params[:keyword]
-    @records=User.search_for(@keyword)
+    @keyword = params[:keyword]
+    @records = User.search_for(@keyword)
   end
 end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,6 +1,6 @@
 class SearchesController < ApplicationController
   def search
-    @keyword = params[:keyword]
-    @records = User.search_for(@keyword)
+    keyword = params[:keyword]
+    @records = User.search_for(keyword)
   end
 end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,6 +1,6 @@
 class SearchesController < ApplicationController
   def search
-    @content=params[:content]
-    @records=User.search_for(@content)
+    @keyword=params[:keyword]
+    @records=User.search_for(@keyword)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -108,6 +108,10 @@ class User < ApplicationRecord
     following.include?(other_user)
   end
 
+  def self.search_for(name)
+      User.where(name: name)
+  end
+
   private
 
     # メールアドレスをすべて小文字にする

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,7 +109,7 @@ class User < ApplicationRecord
   end
 
   def self.search_for(keyword)
-    User.where('email Like ?','%'+keyword+'%').or(User.where('name Like ?','%'+keyword+'%'))
+    User.where('email Like ?', '%'+keyword+'%').or(User.where('name Like ?',' %'+keyword+'%'))
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -108,8 +108,8 @@ class User < ApplicationRecord
     following.include?(other_user)
   end
 
-  def self.search_for(name)
-      User.where(name: name)
+  def self.search_for(keyword)
+    User.where('email Like ?', '%'+keyword+'%').or(User.where('name Like ?','%'+keyword+'%'))
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,7 +109,7 @@ class User < ApplicationRecord
   end
 
   def self.search_for(keyword)
-    User.where('email Like ?', '%'+keyword+'%').or(User.where('name Like ?',' %'+keyword+'%'))
+    User.where('email Like ?', '%' + keyword + '%').or(User.where('name Like ?','%'+ keyword + '%' ))
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,7 +109,7 @@ class User < ApplicationRecord
   end
 
   def self.search_for(keyword)
-    User.where('email Like ?', '%'+keyword+'%').or(User.where('name Like ?','%'+keyword+'%'))
+    User.where('email Like ?','%'+keyword+'%').or(User.where('name Like ?','%'+keyword+'%'))
   end
 
   private

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -1,0 +1,6 @@
+<div class="serch_form">
+    <%= form_with url: search_path,method: :get, local: true do |f| %>
+    <%= f.text_field :content %>
+    <%= f.submit'検索' %>
+    <% end %>
+</div>

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -1,5 +1,5 @@
 <div class="search_form">
-  <%= form_with url: search_path,method: :get, local: true do |f| %>
+  <%= form_with url: search_path, method: :get, local: true do |f| %>
     <%= f.text_field :keyword, :class => 'text_field' %>
     <%= f.submit'検索', :class => 'submit' %>
   <% end %>

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -1,6 +1,6 @@
 <div class="search_form">
-    <%= form_with url: search_path,method: :get, local: true do |f| %>
+  <%= form_with url: search_path,method: :get, local: true do |f| %>
     <%= f.text_field :keyword, :class => 'text_field' %>
     <%= f.submit'検索', :class => 'submit' %>
-    <% end %>
+  <% end %>
 </div>

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -1,6 +1,6 @@
-<div class="serch_form">
+<div class="search_form">
     <%= form_with url: search_path,method: :get, local: true do |f| %>
-    <%= f.text_field :content %>
-    <%= f.submit'検索' %>
+    <%= f.text_field :keyword, :class => 'text_field' %>
+    <%= f.submit'検索', :class => 'submit' %>
     <% end %>
 </div>

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -1,6 +1,6 @@
 <div class="search_form">
   <%= form_with url: search_path, method: :get, local: true do |f| %>
     <%= f.text_field :keyword, :class => 'text_field' %>
-    <%= f.submit'検索', :class => 'submit' %>
+    <%= f.submit '検索', :class => 'submit' %>
   <% end %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,6 @@
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
-    <%= render 'layouts/search' %>
   </head>
   <body>
     <%= render 'layouts/header' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,9 +6,9 @@
     <meta charset="utf-8">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <%= render 'layouts/search' %>
   </head>
   <body>
     <%= render 'layouts/header' %>

--- a/app/views/searches/search.html.erb
+++ b/app/views/searches/search.html.erb
@@ -4,32 +4,32 @@
   <div class="col-xs-12">
     <h2>Users search for '<%= @keyword %>'</h2>
     <% if @records.empty? %>
-        検索したユーザーは見つかりません
+      検索したユーザーは見つかりません
     <% else %>
       <table class="table">
-          <thead>
-              <tr>
-                  <th></th>
-                  <th>Name</th>
-                  <th>Profile</th>
-              </tr>
-          </thead>
-        <% @records.each do |user| %>
-          <tbody>
-              <tr>
-                  <th>
-                      <%= link_to gravatar_for(user, size: 50), current_user %>
-                  </th>
-                  <th>
-                      <%= user.name %>
-                  </th>
-                  <th>
-                      <%= user.profile %>
-                  </th>
-              </tr>
-          </tbody>
-        <% end %>
+        <thead>
+          <tr>
+            <th></th>
+            <th>Name</th>
+            <th>Profile</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @records.each do |user| %>
+            <tr>
+              <td>
+                <%= link_to gravatar_for(user, size: 50), current_user %>
+              </td>
+              <td>
+                <%= user.name %>
+              </td>
+              <td>
+                <%= user.profile %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
       </table>
-      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/searches/search.html.erb
+++ b/app/views/searches/search.html.erb
@@ -2,7 +2,7 @@
 <p>Find me in app/views/searches/search.html.erb</p>
 <div class="container">
   <div class="col-xs-12">
-    <h2>Users search for '<%= @content %>'</h2>
+    <h2>Users search for '<%= @keyword %>'</h2>
     <table class="table">
         <thead>
             <tr>

--- a/app/views/searches/search.html.erb
+++ b/app/views/searches/search.html.erb
@@ -3,29 +3,33 @@
 <div class="container">
   <div class="col-xs-12">
     <h2>Users search for '<%= @keyword %>'</h2>
-    <table class="table">
-        <thead>
-            <tr>
-                <th></th>
-                <th>Name</th>
-                <th>Profile</th>
-            </tr>
-        </thead>
-    <% @records.each do |user| %>
-        <tbody>
-            <tr>
-                <th>
-                    <%= link_to gravatar_for(user, size: 50), current_user %>
-                </th>
-                <th>
-                    <%= user.name %>
-                </th>
-                <th>
-                    <%= user.profile %>
-                </th>
-            </tr>
-        </tbody>
-    <% end %>
-    </table>
+    <% if @records.empty? %>
+        検索したユーザーは見つかりません
+    <% else %>
+      <table class="table">
+          <thead>
+              <tr>
+                  <th></th>
+                  <th>Name</th>
+                  <th>Profile</th>
+              </tr>
+          </thead>
+        <% @records.each do |user| %>
+          <tbody>
+              <tr>
+                  <th>
+                      <%= link_to gravatar_for(user, size: 50), current_user %>
+                  </th>
+                  <th>
+                      <%= user.name %>
+                  </th>
+                  <th>
+                      <%= user.profile %>
+                  </th>
+              </tr>
+          </tbody>
+        <% end %>
+      </table>
+      <% end %>
   </div>
 </div>

--- a/app/views/searches/search.html.erb
+++ b/app/views/searches/search.html.erb
@@ -1,0 +1,31 @@
+<h1>Searches#search</h1>
+<p>Find me in app/views/searches/search.html.erb</p>
+<div class="container">
+  <div class="col-xs-12">
+    <h2>Users search for '<%= @content %>'</h2>
+    <table class="table">
+        <thead>
+            <tr>
+                <th></th>
+                <th>Name</th>
+                <th>Profile</th>
+            </tr>
+        </thead>
+    <% @records.each do |user| %>
+        <tbody>
+            <tr>
+                <th>
+                    <%= link_to gravatar_for(user, size: 50), current_user %>
+                </th>
+                <th>
+                    <%= user.name %>
+                </th>
+                <th>
+                    <%= user.profile %>
+                </th>
+            </tr>
+        </tbody>
+    <% end %>
+    </table>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,10 +1,8 @@
 <% provide(:title, 'All users') %>
 <h1>All users</h1>
 <%= render 'layouts/search' %>
-
 <%= will_paginate %>
 <ul class="users">
   <%= render @users %>
 </ul>
-
 <%= will_paginate %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,8 +1,8 @@
 <% provide(:title, 'All users') %>
 <h1>All users</h1>
+<%= render 'layouts/search' %>
 
 <%= will_paginate %>
-
 <ul class="users">
   <%= render @users %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get    "/login",   to: "sessions#new"
   post   "/login",   to: "sessions#create"
   delete "/logout",  to: "sessions#destroy"
+  get '/search', to: 'searches#search'
   resources :users do
     member do
       get :following, :followers


### PR DESCRIPTION
## チケットURL
#12 

## 概要
ユーザーを名前もしくはメールアドレスでlike検索できるようにした。

## やったこと
HTTPのGETリクエストが/searchというパスに来たときに、SearchesControllerのsearchアクションに処理を渡すようにした。
検索結果をkeynoteとして渡しもしいなかった場合は”検索したユーザーは見つかりません”を表示
モデルファイルに検索条件を追加
ビューで表示できるようにした。


## レビュー観点
ユーザーを名前とmailアドレスの両方でLIke句で検索できること
いなかった場合”検索したユーザーは見つかりません”が表示されること
## 補足
